### PR TITLE
🐛 fix: 성적페이지 피드백칸 삭제

### DIFF
--- a/src/__test__/grade/GradeTable.test.tsx
+++ b/src/__test__/grade/GradeTable.test.tsx
@@ -22,7 +22,6 @@ const students = [
     rank: 1,
     grade: 'A',
     achievementLevel: '상',
-    feedback: '잘함',
   },
   {
     number: 2,
@@ -36,7 +35,6 @@ const students = [
     rank: 2,
     grade: 'B',
     achievementLevel: '중',
-    feedback: '',
   },
 ];
 
@@ -80,7 +78,6 @@ describe('<GradeTable />', () => {
     // 점수 (여러 셀이 있을 수 있으므로 getAllByText 사용)
     expect(screen.getAllByText('170.0').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('A')).toBeInTheDocument();
-    expect(screen.getByText('잘함')).toBeInTheDocument();
   });
 
   it('행 클릭 시 setSelectedRow가 호출된다', () => {

--- a/src/components/grade/GradeTable.tsx
+++ b/src/components/grade/GradeTable.tsx
@@ -33,7 +33,7 @@ export function GradeTable({
           <tr>
             {[
               "번호", "성명", ...evaluations.map(e => e.title),
-              "총점", "환산", "평균", "표준편차", "석차", "등급", "성취도", "피드백(비고)"
+              "총점", "환산", "평균", "표준편차", "석차", "등급", "성취도", 
             ].map((header) => (
               <th key={header} className="px-2 py-2 border">{header}</th>
             ))}
@@ -100,7 +100,6 @@ function GradeTableRow({
       <td className="border px-2 py-1">{student.rank ?? "-"}</td>
       <td className="border px-2 py-1">{student.grade ?? "-"}</td>
       <td className="border px-2 py-1">{student.achievementLevel ?? "-"}</td>
-      <td className="border px-2 py-1">{student.feedback ?? "-"}</td>
     </tr>
   );
 }


### PR DESCRIPTION
### 🔥 작업 내용
-t성적페이지 피드백 칸 삭제

### 🤔 추후 작업 사항
- 테스트 후 수정사항 찾기

### 🔗 이슈
- 

### 📸 피그마 스크린샷 or 기능 GIF
